### PR TITLE
print errors when they occur

### DIFF
--- a/docker/check_all.R
+++ b/docker/check_all.R
@@ -14,7 +14,15 @@ check_all <- function(protocol_code) {
   fail <-
     inherits(test1, "error") | inherits(test2, "error")
   if (fail) {
-    stop("\nThe source code failed some checks. Please check the error message above.\n")
+    stop(
+      sprintf("\nThe source code failed some checks.
+              Please check the error messages:
+              error in check_frontmatter: %1$s
+              error in check_structure: %2$s",
+              test1$message,
+              test2$message
+              )
+      )
   }
 }
 check_all(Sys.getenv("GITHUB_HEAD_REF"))  


### PR DESCRIPTION
improve check_all (also fixed in add-gha-checks branch in fork of protocolsource)