### PR TITLE
trigger build of docker

### DIFF
--- a/docker/entrypoint_update.sh
+++ b/docker/entrypoint_update.sh
@@ -21,7 +21,7 @@ Rscript --no-save --no-restore -e 'protocolhelper:::update_news_release("'$GITHU
 git add NEWS.md
 git commit --message="update general NEWS.md"
 
-echo '\nUpdating doi in index.Rmd...\n'
+echo '\nUpdating doi in index.Rmd ...\n'
 Rscript --no-save --no-restore -e 'protocolhelper:::update_doi(protocol_code = "'$GITHUB_HEAD_REF'", sandbox = TRUE)'
 git add index.Rmd
 git commit --message="update doi in index.Rmd"


### PR DESCRIPTION
## Description

With this small change, I hope to trigger the build of the docker image, as this was not done because the previous branch was given the wrong name.

## Task list

<!--see https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists for an explanation on how to use task lists-->

Steps by contributor:

-   [x] Add description to this pull request (under "## Description")
-   [ ] Open the dropdown (triangle) near 'create pull request' and choose 'Create draft pull request'
-   [ ] Check for potential problems by running `protocolhelper::check_frontmatter()` and address them
-   [ ] Check for potential problems by running `protocolhelper::check_structure()` and address them
-   [ ] Add further commits if needed and push them to GitHub
-   [ ] Update the protocol-specific `NEWS.Rmd`
-   [x] Mark the pull request as 'ready for review'

Review steps for the author(s):

-   [x] Add reviewers, at least one subject-matter specialist and one administrator
-   [ ] Wait for review comments and address them
-   [ ] Iterate until reviewer approvals (merging the pull request will be done by an administrator)
-   [ ] Verify that the checks done by continuous integration succeeded. These will check if `protocolhelper::check_frontmatter()` and `protocolhelper::check_structure()` succeeded without errors.

To be done by an administrator after review: see [guidelines for admins](https://github.com/inbo/protocolsource/blob/main/RELEASES.md).
